### PR TITLE
Fix sections bottom padding for phone devices

### DIFF
--- a/_sass/includes/cards/cards.sass
+++ b/_sass/includes/cards/cards.sass
@@ -25,3 +25,7 @@
   opacity: 0
   animation: fadein 1s 1 forwards
   animation-delay: 0.5s
+
+@media only screen and (max-width: 991px)
+  .sections-wrapper
+    padding-bottom: 185px

--- a/_sass/includes/sidebar/sidebar.sass
+++ b/_sass/includes/sidebar/sidebar.sass
@@ -103,7 +103,7 @@
   margin-bottom: 15px
   padding-left: 0
 
-@media only screen and (max-width: 992px)
+@media only screen and (max-width: 991px)
   .heading-wrapper
     height: auto
 


### PR DESCRIPTION
### What has been done
Added 185px bottom space to compensate for the horizontal header height and make the page content scroll till the bottom.